### PR TITLE
Add onChange callback to Playground

### DIFF
--- a/src/components/playground.jsx
+++ b/src/components/playground.jsx
@@ -12,7 +12,8 @@ class ReactPlayground extends Component {
     theme: "monokai",
     noRender: true,
     context: {},
-    initiallyExpanded: false
+    initiallyExpanded: false,
+    onChange: () => {}
   };
 
   static propTypes = {
@@ -27,7 +28,8 @@ class ReactPlayground extends Component {
     es6Console: PropTypes.bool,
     context: PropTypes.object,
     initiallyExpanded: PropTypes.bool,
-    previewComponent: PropTypes.node
+    previewComponent: PropTypes.node,
+    onChange: PropTypes.func
   };
 
   state = {
@@ -44,10 +46,12 @@ class ReactPlayground extends Component {
   };
 
   _handleCodeChange = (code) => {
+    const { onChange } = this.props;
+
     this.setState({
       code,
       external: false
-    });
+    }, () => onChange(code));
   };
 
   _toggleCode = () => {


### PR DESCRIPTION
Add `onChange` prop to `<Playground />` to allow propagation of code changes outside of the component – this allows use cases such as storing the changes to `localStorage` as you type and restoring them in the future.